### PR TITLE
Fix improper out_size assignment in ImplicitKernel

### DIFF
--- a/models/core/implicit_kernel.py
+++ b/models/core/implicit_kernel.py
@@ -84,7 +84,7 @@ class ImplicitKernel(torch.nn.Module):
             conv_out_type.representations
         )
         self.in_size = conv_in_type.representations[0].size
-        self.out_size = conv_in_type.representations[0].size
+        self.out_size = conv_out_type.representations[0].size
 
         # normalization factor
         self.factor = 1 / math.sqrt(self.c_out)


### PR DESCRIPTION
Hello, 

I noticed this bug that results in an error if the representation sizes of the individual input and output representations (of the convolution layer) are not equal. I believe that making this adjustment should resolve the issue.